### PR TITLE
endpoint to set appdata on external storage

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -9,6 +9,9 @@ return [
 		['name' => 'Local#getRestoringPoints', 'url' => '/rp', 'verb' => 'GET'],
 		['name' => 'Local#getExternalFolder', 'url' => '/external', 'verb' => 'GET'],
 		['name' => 'Local#setExternalFolder', 'url' => '/external', 'verb' => 'POST'],
+		['name' => 'Local#getAppData', 'url' => '/appdata', 'verb' => 'GET'],
+		['name' => 'Local#setAppData', 'url' => '/appdata', 'verb' => 'POST'],
+
 		['name' => 'Local#unsetExternalFolder', 'url' => '/external/{storageId}', 'verb' => 'DELETE'],
 		['name' => 'Local#initAction', 'url' => '/action/{type}/{param}', 'verb' => 'POST']
 	],

--- a/lib/Command/ExternalAppData.php
+++ b/lib/Command/ExternalAppData.php
@@ -72,9 +72,9 @@ class ExternalAppData extends Base {
 	 * @param ConfigService $configService
 	 */
 	public function __construct(
-		PointService          $pointService,
+		PointService $pointService,
 		ExternalFolderService $externalFolderService,
-		ConfigService         $configService
+		ConfigService $configService
 	) {
 		parent::__construct();
 
@@ -129,11 +129,6 @@ class ExternalAppData extends Base {
 
 		$external = $this->externalFolderService->getStorageById($storageId);
 		$output->writeln('');
-		if ($external->getRoot() !== '') {
-			$output->writeln('This external filesystem is already used by the Backup App');
-
-			return 0;
-		}
 
 		$external->setRoot($root);
 
@@ -157,10 +152,7 @@ class ExternalAppData extends Base {
 			return 0;
 		}
 
-
-		$this->pointService->destroyBackupFS();
-		$this->configService->setAppValueArray(ConfigService::EXTERNAL_APPDATA, $this->serialize($external));
-
+		$this->pointService->setExternalAppData($storageId, $root);
 		$output->writeln('done');
 
 		return 0;

--- a/lib/Controller/LocalController.php
+++ b/lib/Controller/LocalController.php
@@ -40,6 +40,7 @@ use OC\Files\Node\File;
 use OC\Files\Node\Folder;
 use OC\User\NoUserException;
 use OCA\Backup\Db\EventRequest;
+use OCA\Backup\Exceptions\ExternalAppdataException;
 use OCA\Backup\Exceptions\RestoringPointException;
 use OCA\Backup\Exceptions\RestoringPointNotFoundException;
 use OCA\Backup\Model\BackupEvent;
@@ -232,6 +233,43 @@ class LocalController extends OcsController {
 					'content' => $content
 				]
 			);
+		} catch (Exception $e) {
+			throw new OcsException($e->getMessage(), Http::STATUS_BAD_REQUEST);
+		}
+	}
+
+
+	/**
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function getAppData(): DataResponse {
+		try {
+			return new DataResponse($this->pointService->getExternalAppData());
+		} catch (ExternalAppdataException $e) {
+			return new DataResponse([]);
+		} catch (Exception $e) {
+			throw new OcsException($e->getMessage(), Http::STATUS_BAD_REQUEST);
+		}
+	}
+
+
+	/**
+	 * @param int $storageId
+	 * @param string $root
+	 *
+	 * @return DataResponse
+	 * @throws OCSException
+	 */
+	public function setAppData(int $storageId, string $root): DataResponse {
+		try {
+			if ($root === '') {
+				throw new OcsException('empty root');
+			}
+
+			$this->pointService->setExternalAppData($storageId, $root);
+
+			return $this->getAppData();
 		} catch (Exception $e) {
 			throw new OcsException($e->getMessage(), Http::STATUS_BAD_REQUEST);
 		}

--- a/lib/Db/PointRequest.php
+++ b/lib/Db/PointRequest.php
@@ -108,6 +108,15 @@ class PointRequest extends PointRequestBuilder {
 
 
 	/**
+	 *
+	 */
+	public function deleteAll() {
+		$qb = $this->getPointDeleteSql();
+
+		$qb->execute();
+	}
+
+	/**
 	 * @param string $pointId
 	 */
 	public function deletePoint(string $pointId): void {
@@ -207,4 +216,5 @@ class PointRequest extends PointRequestBuilder {
 
 		return $this->getItemsFromRequest($qb);
 	}
+
 }

--- a/lib/Service/ExternalFolderService.php
+++ b/lib/Service/ExternalFolderService.php
@@ -852,7 +852,7 @@ class ExternalFolderService {
 			}
 		}
 
-		throw new ExternalFolderNotFoundException();
+		throw new ExternalFolderNotFoundException('storage not found');
 	}
 
 


### PR DESCRIPTION
### get current configuration for _appdata-on-external-storage_

```
curl -X GET -u 'admin/admin' -H "OCS-ApiRequest: true" "http://backup.local/ocs/v2.php/apps/backup/appdata?format=json"  | jq
{
  "ocs": {
    "meta": {
      "status": "ok",
      "statuscode": 200,
      "message": "OK"
    },
    "data": {
      "storageId": 3,
      "storage": "local::/home/backup/",
      "root": "/toto"
    }
  }
}
```
data is empty if appdata is not yet configured to use external storage.

### set external storage for appdata:

```
$ curl -X POST -u 'admin:admin' -H "OCS-ApiRequest: true" "http://backup.local/ocs/v2.php/apps/backup/appdata?format=json" -H "Content-type: application/json" -d '{"storageId": 4, "root": "/appdata/"}' | jq
{
  "ocs": {
    "meta": {
      "status": "ok",
      "statuscode": 200,
      "message": "OK"
    },
    "data": {
      "storageId": 4,
      "storage": "local::/home/backup/",
      "root": "/appdata/"
    }
  }
}
```

if `storageId === 0` current external storage will be unset and the backup app will returns at using datadirectory for its appdata

