### PR TITLE
generate local log file

### DIFF
--- a/lib/Command/PointCreate.php
+++ b/lib/Command/PointCreate.php
@@ -86,7 +86,10 @@ class PointCreate extends Base {
 		$this->setName('backup:point:create')
 			 ->setDescription('Generate a restoring point of the instance (complete or incremental)')
 			 ->addArgument('comment', InputArgument::OPTIONAL, 'set a comment to the restoring point', '')
-			 ->addOption('differential', '', InputOption::VALUE_NONE, 'create an differential restoring point');
+			 ->addOption('generate-log', '', InputOption::VALUE_NONE, 'generate a log file')
+			 ->addOption(
+				 'differential', '', InputOption::VALUE_NONE, 'create an differential restoring point'
+			 );
 	}
 
 
@@ -111,7 +114,11 @@ class PointCreate extends Base {
 			$this->outputService->setOutput($output);
 		}
 
-		$point = $this->pointService->create(!$input->getOption('differential'), $input->getArgument('comment'));
+		$point = $this->pointService->create(
+			!$input->getOption('differential'),
+			$input->getArgument('comment'),
+			($input->getOption('generate-log')) ? 'occ backup:point:create' : '',
+		);
 
 		if ($o === 'none') {
 			return 0;

--- a/lib/Command/PointUpload.php
+++ b/lib/Command/PointUpload.php
@@ -43,6 +43,7 @@ use OCA\Backup\Service\RemoteService;
 use OCA\Backup\Service\UploadService;
 use OCP\Files\NotFoundException;
 use OCP\Files\NotPermittedException;
+use OCP\Lock\LockedException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -100,7 +101,8 @@ class PointUpload extends Base {
 			 ->setDescription('Upload a local restoring point on others instances')
 			 ->addArgument('point', InputArgument::REQUIRED, 'Id of the restoring point')
 			 ->addOption('remote', '', InputOption::VALUE_REQUIRED, 'address of the remote instance', '')
-			 ->addOption('external', '', InputOption::VALUE_REQUIRED, 'id of the external folder', '');
+			 ->addOption('external', '', InputOption::VALUE_REQUIRED, 'id of the external folder', '')
+			 ->addOption('generate-log', '', InputOption::VALUE_NONE, 'generate a log file');
 	}
 
 
@@ -120,6 +122,14 @@ class PointUpload extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$point = $this->pointService->getLocalRestoringPoint($input->getArgument('point'));
 
+		if ($input->getOption('generate-log')) {
+			try {
+				$this->pointService->initBaseFolder($point);
+				$this->outputService->openFile($point, 'occ backup:point:upload');
+			} catch (NotPermittedException | LockedException $e) {
+			}
+		}
+
 		$this->outputService->setOutput($output);
 		if ($input->getOption('external')) {
 			$this->uploadService->initUpload($point);
@@ -134,7 +144,6 @@ class PointUpload extends Base {
 
 			return 0;
 		}
-
 
 		$this->uploadService->uploadPoint($point);
 

--- a/lib/Cron/Backup.php
+++ b/lib/Cron/Backup.php
@@ -119,9 +119,16 @@ class Backup extends TimedJob {
 
 	private function runFullBackup(): void {
 		try {
-			$this->pointService->create(true);
+			$generateLogs = $this->configService->getAppValueBool(ConfigService::GENERATE_LOGS);
+			$this->pointService->create(
+				true,
+				'',
+				($generateLogs) ? 'Backup Background Job (complete)' : ''
+			);
 		} catch (Throwable $e) {
-			$this->loggerInterface->debug('error while running full backup - ' . json_encode(debug_backtrace()));
+			$this->loggerInterface->debug(
+				'error while running full backup - ' . json_encode(debug_backtrace())
+			);
 		}
 	}
 
@@ -131,9 +138,16 @@ class Backup extends TimedJob {
 	 */
 	private function runDifferentialBackup(): void {
 		try {
-			$this->pointService->create(false);
+			$generateLogs = $this->configService->getAppValueBool(ConfigService::GENERATE_LOGS);
+			$this->pointService->create(
+				false,
+				'',
+				($generateLogs) ? 'Backup Background Job (partial)' : ''
+			);
 		} catch (Throwable $e) {
-			$this->loggerInterface->error('error while running differential backup - ' . json_encode(debug_backtrace()));
+			$this->loggerInterface->error(
+				'error while running differential backup - ' . json_encode(debug_backtrace())
+			);
 		}
 	}
 }

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -62,6 +62,7 @@ class ConfigService {
 	public const LAST_PARTIAL_RP = 'last_partial_rp';
 	public const PACK_BACKUP = 'pack_backup';
 	public const BACKUP_DAYS = 'backup_days';
+	public const GENERATE_LOGS = 'generate_logs';
 
 	public const INCLUDE_LOGS = 'include_logs';
 	public const PACK_ENCRYPT = 'pack_encrypt';
@@ -102,6 +103,7 @@ class ConfigService {
 		self::TIME_SLOTS => '23-5',
 		self::MOCKUP_DATE => 0,
 		self::BACKUP_DAYS => 60,
+		self::GENERATE_LOGS => 0,
 
 		self::INCLUDE_LOGS => '1',
 		self::PACK_ENCRYPT => '1',


### PR DESCRIPTION
if `generate_logs` is set to '1' (default '0') a log file will be generated at the root of the restoring point.

The hardest part was to get a `File` instead of `SimpleFile` (which limit the writing options to `'w'`) from the AppData folder so PHP can `append` the log entries to the file.