### PR TITLE
+cron_enabled

### DIFF
--- a/lib/Cron/Backup.php
+++ b/lib/Cron/Backup.php
@@ -74,7 +74,7 @@ class Backup extends TimedJob {
 		ConfigService $configService,
 		LoggerInterface $loggerInterface
 	) {
-		$this->setInterval(9);
+		$this->setInterval(900);
 
 		$this->pointService = $pointService;
 		$this->cronService = $cronService;

--- a/lib/Cron/Backup.php
+++ b/lib/Cron/Backup.php
@@ -74,7 +74,7 @@ class Backup extends TimedJob {
 		ConfigService $configService,
 		LoggerInterface $loggerInterface
 	) {
-		$this->setInterval(900);
+		$this->setInterval(9);
 
 		$this->pointService = $pointService;
 		$this->cronService = $cronService;

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -48,6 +48,7 @@ class ConfigService {
 	public const DATA_DIRECTORY = 'datadirectory';
 	public const LOGFILE = 'logfile';
 
+	public const CRON_ENABLED = 'cron_enabled';
 	public const LOCK = 'lock';
 	public const REMOTE_ENABLED = 'remote_enabled';
 	public const EXTERNAL_APPDATA = 'external_appdata';
@@ -82,6 +83,7 @@ class ConfigService {
 
 	/** @var array */
 	public $defaults = [
+		self::CRON_ENABLED => 1,
 		self::LOCK => 0,
 		self::REMOTE_ENABLED => 0,
 		self::EXTERNAL_APPDATA => '{}',
@@ -370,6 +372,7 @@ class ConfigService {
 	 */
 	public function getSettings(): array {
 		return [
+			self::CRON_ENABLED => $this->getAppValueBool(self::CRON_ENABLED),
 			self::DATE_FULL_RP => $this->getAppValueInt(self::DATE_FULL_RP),
 			self::DATE_PARTIAL_RP => $this->getAppValueInt(self::DATE_PARTIAL_RP),
 			self::TIME_SLOTS => $this->getAppValue(self::TIME_SLOTS),
@@ -394,6 +397,9 @@ class ConfigService {
 	public function setSettings(array $settings): array {
 		$data = new SimpleDataStore($settings);
 
+		if ($data->hasKey(self::CRON_ENABLED)) {
+			$this->setAppValueBool(self::CRON_ENABLED, $data->gBool(self::CRON_ENABLED));
+		}
 		if ($data->hasKey(self::TIME_SLOTS)) {
 			$this->setAppValue(self::TIME_SLOTS, $data->g(self::TIME_SLOTS));
 		}

--- a/lib/Service/CronService.php
+++ b/lib/Service/CronService.php
@@ -407,6 +407,12 @@ class CronService {
 	public function isRealCron(): bool {
 		$mode = $this->configService->getCoreValue('backgroundjobs_mode', '');
 
+		if (!$this->configService->getAppValueBool(ConfigService::CRON_ENABLED)) {
+			return false;
+		}
+
+		$this->configService->setAppValueBool(ConfigService::CRON_ENABLED, true);
+
 		return (strtolower($mode) === 'cron' || strtolower($mode) === 'webcron');
 	}
 }


### PR DESCRIPTION
right now, cron are forced and cannot be disabled.
This PR creates a new app config: `cron_enabled`.
It also feed the set/get settings on the endpoint.

@artonge we need to add a checkbox on the Settings Page.

Note: Because the current version of the app do run background jobs by default, the default value of `cron_enabled` is `1` and will be set as '1' in the database. The idea behind this is that it might be better to switch the default value to `0` after few releases so that old installation of the app still have the flag to `1` while new installation of the app have the right default value, and will need to enable the feature throw the Admin Settings page
 